### PR TITLE
Language simplifications for body & neurotype

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Some Spectrum-sponsored spaces may have additional rules in place, which will be
 
 Harassment includes:
 
-* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neurotype, physical appearance, body, race, or religion
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behaviour  in spaces where they’re not appropriate


### PR DESCRIPTION
I think this takes two opportunities to simplify language while preserving meaning:

* body size -> body, because body size is one aspect of a person's body and the others can be just as sensitive
* neuro(a)typicality -> neurotype, a simpler word that includes both neurotypical and neuroatypical